### PR TITLE
Fix: unknown behavior names: binary, password, username

### DIFF
--- a/django_ft_cache.py
+++ b/django_ft_cache.py
@@ -31,9 +31,7 @@ class FaultTolerantCacheMixin(object):
     @cached_property
     def _cache(self):
         # existing Django code
-        client = self._lib.Client(self._servers)
-        if self._options:
-            client._options = self._options
+        client = self._lib.Client(self._servers, **self._options)
         # overrides
         for name in self.methods_to_patch:
                 method = fault_tolerant_wrapper(getattr(client, name))

--- a/django_ft_cache.py
+++ b/django_ft_cache.py
@@ -33,7 +33,7 @@ class FaultTolerantCacheMixin(object):
         # existing Django code
         client = self._lib.Client(self._servers)
         if self._options:
-            client.behaviors = self._options
+            client._options = self._options
         # overrides
         for name in self.methods_to_patch:
                 method = fault_tolerant_wrapper(getattr(client, name))

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ try:
 except ImportError:
     from distutils.core import setup, Command
 
-version = '1.0.0'
+version = '1.0.1'
 
 if sys.argv[-1] == 'publish':
     os.system('python setup.py sdist upload')


### PR DESCRIPTION
When I tried to pass:


````
'default': {
        'BACKEND': 'django_ft_cache.FaultTolerantPyLibMCCache',
        'LOCATION': env.str('MEMC_URL'),
        'TIMEOUT': None,
        'OPTIONS': {
            'binary': True,
            'username': env.str('MEMC_USERNAME', None),
            'password': env.str('MEMC_PASSWORD', None),
        }
````

Package stopped working with 

```
unknown behavior names: binary, password, username
```

Why did you use `_behaviours` ?